### PR TITLE
Change blue used by tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ coverage
 node_modules
 stats.json
 package-lock.json
+yarn.lock
 
 # Cruft
 .DS_Store

--- a/admin/src/components/Tabs/Wrapper.js
+++ b/admin/src/components/Tabs/Wrapper.js
@@ -23,10 +23,10 @@ const Wrapper = styled.div`
     flex: 1 100%;
     height: 3.6rem;
     border-radius: 2px 0 0 0;
-    background-color: darken(#f5f5f5, 50%);
+    background-color: #f2f3f4;
     text-decoration: none !important;
-    font-family: Lato;
     font-size: 1.3rem;
+    font-weight: 500;
     color: #333740 !important;
     line-height: 1.6rem;
     &.linkActive {
@@ -35,7 +35,7 @@ const Wrapper = styled.div`
       font-weight: bold;
       text-decoration: none !important;
       box-shadow: 0 0 2px rgba(#dbdbdb, 0.5);
-      border-top: 0.2rem solid #1c5de7;
+      ${({theme}) => { return { borderTop: `2px solid ${theme.main.colors.blue}` }}}
     }
   }
   .linkText {


### PR DESCRIPTION
These changes make the look of the tabs consistent with the [tabs in the roles edit page](https://github.com/strapi/strapi/tree/master/packages/strapi-admin/admin/src/components/Roles/Tabs)

- Read blue color value from theme
- Remove explicit font-family (as it is not present in strapi's implementation)
- Make unselected text semi bold
---
- Adds `yarn.lock` to `.gitignore`