### PR TITLE
Fix uppercase headings

### DIFF
--- a/services/email.js
+++ b/services/email.js
@@ -40,7 +40,7 @@ const sendTemplatedEmail = async (emailOptions = {}, emailTemplate = {}, data = 
     .findOne({ id: emailTemplate.templateId });
 
   if ((!bodyText || !bodyText.length) && bodyHtml && bodyHtml.length)
-    bodyText = htmlToText(bodyHtml, { wordwrap: 130, trimEmptyLines: true });
+    bodyText = htmlToText(bodyHtml, { wordwrap: 130, trimEmptyLines: true, uppercaseHeadings: false });
 
   emailTemplate = {
     ...emailTemplate,


### PR DESCRIPTION
### Description
The `htmlToText` function converts the headings tags to [uppercase by default](https://github.com/html-to-text/node-html-to-text#format-options). This behavior can create potential errors when lodash interpolates variables (a lowercase variable parsed as uppercase) It is possible to pass an option, `uppercaseHeadings`, to disable this behavior in order to make the heading tags work as expected when they contain interpolation.  Hope it can be of help =).

Fixes #36