### PR TITLE
fix: do not get config property during initialization

### DIFF
--- a/services/email.js
+++ b/services/email.js
@@ -9,8 +9,6 @@ const decode = require('decode-html');
 const { htmlToText } = require('html-to-text');
 const { isEmpty } = require('lodash');
 
-const { mantainLegacyTemplate = true } = (strapi.plugins['email-designer'] || {}).config || {};
-
 const templateSettings = {
   evaluate: /\{\{(.+?)\}\}/g,
   interpolate: /\{\{=(.+?)\}\}/g,
@@ -18,6 +16,8 @@ const templateSettings = {
 };
 
 const templater = (tmpl) => _.template(tmpl, templateSettings);
+
+const isMantainLegacyTemplateActive = () => _.get(strapi.plugins, 'email-designer.config.mantainLegacyTemplate', true)
 
 /**
  * fill subject, text and html using lodash template
@@ -60,7 +60,7 @@ const sendTemplatedEmail = async (emailOptions = {}, emailTemplate = {}, data = 
     ({ bodyHtml, bodyText, subject } = response);
   }
 
-  if (mantainLegacyTemplate) {
+  if (isMantainLegacyTemplateActive()) {
     bodyHtml = bodyHtml.replace(/<%/g, '{{').replace(/%>/g, '}}');
     bodyText = bodyText.replace(/<%/g, '{{').replace(/%>/g, '}}');
     subject = subject.replace(/<%/g, '{{').replace(/%>/g, '}}');
@@ -103,7 +103,7 @@ const compose = async ({ templateId, data = {} }) => {
     .query('email-template', 'email-designer')
     .findOne({ id: templateId });
 
-  if (mantainLegacyTemplate) {
+  if (isMantainLegacyTemplateActive()) {
     bodyHtml = bodyHtml.replace(/<%/g, '{{').replace(/%>/g, '}}');
     bodyText = bodyText.replace(/<%/g, '{{').replace(/%>/g, '}}');
     subject = subject.replace(/<%/g, '{{').replace(/%>/g, '}}');


### PR DESCRIPTION
the config was empty at this moment, so I put a function to retrive `mantainLegacyTemplate` property when needed instead of doing that at the beginning.
Also, I needed to deactivate `mantainLegacyTemplate` because I encountered errors in the `sendTemplatedEmail` function, here
```
if (mantainLegacyTemplate()) {
  bodyHtml = bodyHtml.replace(/<%/g, '{{').replace(/%>/g, '}}');
  bodyText = bodyText.replace(/<%/g, '{{').replace(/%>/g, '}}');
  subject = subject.replace(/<%/g, '{{').replace(/%>/g, '}}');
}
```
I think that the previous `findOne`query doesn't return string for `bodyText` prooperty (mine is empty), so the replace method will throw an error. Maybe it depends on the type of database, but in my case when `mantainLegacyTemplate` is true (default) the functions stops working in the condition block.