### PR TITLE
Fix server config not being loaded after the Email Designer has been mounted

### DIFF
--- a/admin/src/containers/Designer/index.js
+++ b/admin/src/containers/Designer/index.js
@@ -99,6 +99,7 @@ const EmailDesigner = ({ isCore = false }) => {
   const [filesToUpload /* , setFilesToUpload */] = useState({});
 
   const [configLoaded, setConfigLoaded] = useState(false);
+  const [serverConfigLoaded, setServerConfigLoaded] = useState(false);
 
   const [editorAppearance, setEditorAppearance] = useState({ ...defaultEditorAppearance });
   const [editorTools, setEditorTools] = useState({ ...defaultEditorTools });
@@ -167,6 +168,7 @@ const EmailDesigner = ({ isCore = false }) => {
         if (editorConfigApi.appearance) {
           setEditorAppearance((state) => merge({}, state, editorConfigApi.appearance));
         }
+        setServerConfigLoaded(true);
       }
 
       emailEditorRef.current?.editor?.loadDesign(_templateData.design);
@@ -335,6 +337,7 @@ const EmailDesigner = ({ isCore = false }) => {
             <div style={{ height: '100%', display: mode === 'html' ? 'flex' : 'none' }}>
               <React.StrictMode>
                 <EmailEditor
+                  key={serverConfigLoaded ? 'server-config' : 'default-config'}
                   ref={emailEditorRef}
                   onLoad={onLoadHandler}
                   style={{ border: '1px solid #dedede' }}


### PR DESCRIPTION
Hi there!

Great plugin you have here, I've just installed and noticed there was no way to add settings from the `config/plugins.js` file.
As I've checked, it seems to be related to this issue: https://github.com/unlayer/react-email-editor/issues/202

This workaround fixed the problem for us.