### PR TITLE
chore: don't validate defined keys as e-mail addresses

### DIFF
--- a/services/email.js
+++ b/services/email.js
@@ -27,9 +27,11 @@ const isMantainLegacyTemplateActive = () => _.get(strapi.plugins, 'email-designe
  * @returns {{ subject, text, subject }}
  */
 const sendTemplatedEmail = async (emailOptions = {}, emailTemplate = {}, data = {}) => {
+  const keysToIgnore = ['attachment', 'attachments'];
+
   Object.entries(emailOptions).forEach(([key, address]) => {
     // ⬇︎ Thanks to @xcivit 's #39 suggestion
-    if (key !== 'attachments') {
+    if (!keysToIgnore.includes(key)) {
       if (Array.isArray(address)) {
         address.forEach((email) => {
           if (!isValidEmail.test(email)) throw new Error(`Invalid "${key}" email address with value "${email}"`);


### PR DESCRIPTION
closes #71 

This PR just adds an array with keys that should not get checked as e-mails. 
We could also remove the e-mail validation all together. Then we won't need to add additional keys to this array in the future.
Let me know what you think. Thanks.