### PR TITLE
Fix: Error when building in production on Strapi 4.1.8

### DIFF
--- a/admin/src/pages/HomePage/index.js
+++ b/admin/src/pages/HomePage/index.js
@@ -147,7 +147,7 @@ const HomePage = () => {
       setImportLoading(true);
       let _importedTemplates = [];
 
-      for await (const template of importedTemplates) {
+      for (const template of importedTemplates) {
         console.log('💬 :: forawait :: template', template);
         const response = await request(`/${pluginId}/templates/${template.id}`, {
           method: 'POST',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

This PR fixes the bug mention here #93. This is done by removing one `await` keyword inside the `handleTemplatesImport` method. 

### Why is it needed?

Because of this bug, it was not possible to build the admin ui in production.

### How to test it?

If the bug fix is applied, I can build my Strapi project without any errors. All functions seem to work as well.

### Related issue(s)/PR(s)

Doesn't work with Strapi v4.1.8 #93
