### PR TITLE
[WIP] BREAKING CHANGE: using mustache template engine

### DIFF
--- a/admin/src/pages/Designer/index.js
+++ b/admin/src/pages/Designer/index.js
@@ -178,17 +178,17 @@ const currentTemplateTags = {
       mergeTags: [
         {
           name: 'First Name',
-          value: '{{= USER.firstname }}',
+          value: '{{ USER.firstname }}',
           sample: (userInfo && userInfo.firstname) || 'John',
         },
         {
           name: 'Last Name',
-          value: '{{= USER.lastname }}',
+          value: '{{ USER.lastname }}',
           sample: (userInfo && userInfo.lastname) || 'Doe',
         },
         {
           name: 'Email',
-          value: '{{= USER.username }}',
+          value: '{{ USER.username }}',
           sample: (userInfo && userInfo.username) || 'john@doe.com',
         },
       ],
@@ -196,7 +196,7 @@ const currentTemplateTags = {
   ],
   mergeTagsConfig: {
     autocompleteTriggerChar: '@',
-    delimiter: ['{{=', '}}'],
+    delimiter: ['{{', '}}'],
   },
 };
 
@@ -408,7 +408,7 @@ const EmailDesignerPage = ({ isCore = false }) => {
           .replace(/\n/g, '<br />');
 
         _templateData.design = JSON.parse(
-          JSON.stringify(standardEmailRegistrationTemplate).replace('__PLACEHOLDER__', _message)
+          JSON.stringify(standardEmailRegistrationTemplate).replace('__PLACEHOLDER__', _message),
         );
       }
 
@@ -490,9 +490,11 @@ const EmailDesignerPage = ({ isCore = false }) => {
                 value={templateData?.subject || ''}
               />
             </Box>
-            <Button onClick={saveDesign} color="success">
-              {getMessage('designer.action.saveTemplate')}
-            </Button>
+            <Box padding={0} style={{ display: 'flex', alignItems: 'flex-end', whiteSpace: 'nowrap' }}>
+              <Button onClick={saveDesign} color="success" size={1}>
+                {getMessage('designer.action.saveTemplate')}
+              </Button>
+            </Box>
           </Bar>
 
           <TabGroup

--- a/package.json
+++ b/package.json
@@ -18,26 +18,26 @@
     "prettier:write": "prettier --write **/*.js"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^6.2.1",
-    "@fortawesome/free-solid-svg-icons": "^6.2.1",
+    "@fortawesome/fontawesome-svg-core": "^6.4.2",
+    "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "dayjs": "^1.11.7",
+    "dayjs": "^1.11.9",
     "decode-html": "^2.0.0",
-    "html-to-text": "^9.0.1",
+    "html-to-text": "^9.0.5",
     "lodash": "^4.17.21",
-    "react-email-editor": "^1.6.3",
+    "react-email-editor": "^1.7.8",
     "react-github-btn": "^1.4.0",
     "react-syntax-highlighter": "^15.5.0",
     "striptags": "^3.2.0"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.19.1",
-    "cypress": "^12.0.1",
-    "eslint": "^8.29.0",
-    "prettier": "^2.8.0"
+    "@babel/eslint-parser": "^7.22.10",
+    "cypress": "^12.17.4",
+    "eslint": "^8.47.0",
+    "prettier": "^3.0.2"
   },
   "peerDependencies": {
-    "@strapi/strapi": "^4.0.0"
+    "@strapi/strapi": "^4.12.4"
   },
   "author": {
     "name": "Alexandre Zaganelli",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "decode-html": "^2.0.0",
     "html-to-text": "^9.0.5",
     "lodash": "^4.17.21",
+    "mustache": "^4.2.0",
     "react-email-editor": "^1.7.8",
     "react-github-btn": "^1.4.0",
     "react-syntax-highlighter": "^15.5.0",

--- a/server/services/email.js
+++ b/server/services/email.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const Mustache = require('mustache');
 // From: https://stackoverflow.com/questions/201323/how-can-i-validate-an-email-address-using-a-regular-expression
 const isValidEmail =
   /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
@@ -9,15 +10,7 @@ const decode = require('decode-html');
 const { htmlToText } = require('html-to-text');
 const { isEmpty } = require('lodash');
 
-const templateSettings = {
-  evaluate: /\{\{(.+?)\}\}/g,
-  interpolate: /\{\{=(.+?)\}\}/g,
-  escape: /\{\{-(.+?)\}\}/g,
-};
-
 module.exports = ({ strapi }) => {
-  const templater = (tmpl) => _.template(tmpl, templateSettings);
-
   const isMantainLegacyTemplateActive = () =>
     _.get(strapi.plugins, 'email-designer.config.mantainLegacyTemplate', true);
 
@@ -88,9 +81,9 @@ module.exports = ({ strapi }) => {
     const templatedAttributes = attributes.reduce(
       (compiled, attribute) =>
         emailTemplate[attribute]
-          ? Object.assign(compiled, { [attribute]: templater(emailTemplate[attribute])(data) })
+          ? Object.assign(compiled, { [attribute]: Mustache.render(emailTemplate[attribute], data) })
           : compiled,
-      {}
+      {},
     );
 
     return strapi.plugin('email').provider.send({ ...emailOptions, ...templatedAttributes });
@@ -127,9 +120,9 @@ module.exports = ({ strapi }) => {
     const templatedAttributes = attributes.reduce(
       (compiled, attribute) =>
         emailTemplate[attribute]
-          ? Object.assign(compiled, { [attribute]: templater(emailTemplate[attribute])(data) })
+          ? Object.assign(compiled, { [attribute]: Mustache.render(emailTemplate[attribute], data) })
           : compiled,
-      {}
+      {},
     );
 
     return {


### PR DESCRIPTION
### What does it do?
This PR introduces [mustache](https://github.com/janl/mustache.js) instead of lodash as the template engine to fix email template vulnerability mentioned [here](https://github.com/alexzaganelli/strapi-plugin-email-designer/issues/123#issuecomment-1531438696) by @Ccamm.

⚠️ This PR introduces a **BREAKING CHANGE** since it changes how users implement variables into their email templates.
_Maybe there is a way to make it backwards compatible?_

### Why is it needed?
Read about the vulnerability [here](https://www.ghostccamm.com/blog/multi_strapi_vulns/#cve-2023-22621-ssti-to-rce-by-exploiting-email-templates-in-strapi-versions-455)

### ToDo

- [ ] Update Docs
- [x] Check if this fixes #120 

### How to test it?

1. Create a new email template with following text content:
```mustache
Hello, {{USER.firstname}} {{USER.lastname}}!


Products:
{{#order.products}}
Name: {{name}} | Price: ${{price}}
{{/order.products}}


Shipping:
${{shippingCost}}

Total: ${{total}}
```

2. Send Template with following code:
```js
try {
  await strapi
    .plugin("email-designer")
    .service("email")
    .sendTemplatedEmail(
      {
        to: "to@example.com",
        attachments: [],
      },
      {
        templateReferenceId: 100,
        subject: `Thank you for your order`,
      },
      {
        USER: {
          firstname: "John",
          lastname: "Doe",
        },
        order: {
          products: [
            { name: "Article 1", price: 9.99 },
            { name: "Article 2", price: 5.55 },
          ],
        },
        shippingCost: 5,
        total: 20.54,
      },
    );

  return ctx.send({ ok: true });
} catch (err) {
  strapi.log.debug("📺: ", err);
  return ctx.badRequest(null, err);
}
```

### Related issue(s)/PR(s)

fix: #123 
