### PR TITLE
fixed missing component NotFound

### DIFF
--- a/admin/src/pages/App/index.js
+++ b/admin/src/pages/App/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
-import { NotFound } from '@strapi/helper-plugin';
+import { AnErrorOccurred } from '@strapi/helper-plugin';
 
 // Utils
 import styled from 'styled-components';
@@ -23,7 +23,7 @@ const App = () => {
         <Route path={`/plugins/${pluginId}/design/:templateId`} component={() => <Designer />} exact />
         <Route path={`/plugins/${pluginId}/core/:coreEmailType`} component={() => <Designer isCore />} exact />
         <Route path={`/plugins/${pluginId}/how-to`} component={HowToPage} exact />
-        <Route component={NotFound} />
+        <Route component={AnErrorOccurred} />
       </Switch>
     </PluginViewWrapper>
   );


### PR DESCRIPTION
This PR is to fix the issue #130.

According to this commit : https://github.com/strapi/strapi/pull/16335/commits/eb2cf3a987b37526fb27314ffa04e58356e5cdb6, the component has been renamed from NotFound to 

### What does it do?

Renames the imported component from NotFound to AnErrorOccurred.

### Why is it needed?

There was a warning using recent version of Strapi with this plugin.

### How to test it?

Run `npm run build` on a project using this plugin and see the disappearance of the build warning.

### Related issue(s)/PR(s)

[Let us know if this is related to any issue/pull request](https://github.com/alexzaganelli/strapi-plugin-email-designer/issues/130)

